### PR TITLE
chore(deps): bump @nextcloud/webpack-vue-config from 6.1.0 to 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,9 +3133,9 @@
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.1.0.tgz",
-			"integrity": "sha512-4xNWh8OeIbsQH5V5BTtLtrWQseEfJ/4E/ra/j5EWoc5vfQqStqDsDTZAyqASlVKaRZs7oBqeFnPTfU+wRb0olQ==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/webpack-vue-config/-/webpack-vue-config-6.1.1.tgz",
+			"integrity": "sha512-PXQKXbDDTq1FxOd6hBmK60FT2pLZGk7kMnoAkOFPN7f2mstIZQUgIUvPuXbhFfbtonc1mVx4I4Qj5C6oZxQaJg==",
 			"dev": true,
 			"license": "AGPL-3.0-or-later",
 			"engines": {
@@ -3228,47 +3228,47 @@
 			"peer": true
 		},
 		"node_modules/@shikijs/core": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.17.7.tgz",
-			"integrity": "sha512-ZnIDxFu/yvje3Q8owSHaEHd+bu/jdWhHAaJ17ggjXofHx5rc4bhpCSW+OjC6smUBi5s5dd023jWtZ1gzMu/yrw==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.21.0.tgz",
+			"integrity": "sha512-zAPMJdiGuqXpZQ+pWNezQAk5xhzRXBNiECFPcJLtUdsFM3f//G95Z15EHTnHchYycU8kIIysqGgxp8OVSj1SPQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@shikijs/engine-javascript": "1.17.7",
-				"@shikijs/engine-oniguruma": "1.17.7",
-				"@shikijs/types": "1.17.7",
+				"@shikijs/engine-javascript": "1.21.0",
+				"@shikijs/engine-oniguruma": "1.21.0",
+				"@shikijs/types": "1.21.0",
 				"@shikijs/vscode-textmate": "^9.2.2",
 				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.2"
+				"hast-util-to-html": "^9.0.3"
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.17.7.tgz",
-			"integrity": "sha512-wwSf7lKPsm+hiYQdX+1WfOXujtnUG6fnN4rCmExxa4vo+OTmvZ9B1eKauilvol/LHUPrQgW12G3gzem7pY5ckw==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.21.0.tgz",
+			"integrity": "sha512-jxQHNtVP17edFW4/0vICqAVLDAxmyV31MQJL4U/Kg+heQALeKYVOWo0sMmEZ18FqBt+9UCdyqGKYE7bLRtk9mg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@shikijs/types": "1.17.7",
+				"@shikijs/types": "1.21.0",
 				"@shikijs/vscode-textmate": "^9.2.2",
 				"oniguruma-to-js": "0.4.3"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.17.7.tgz",
-			"integrity": "sha512-pvSYGnVeEIconU28NEzBXqSQC/GILbuNbAHwMoSfdTBrobKAsV1vq2K4cAgiaW1TJceLV9QMGGh18hi7cCzbVQ==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.21.0.tgz",
+			"integrity": "sha512-AIZ76XocENCrtYzVU7S4GY/HL+tgHGbVU+qhiDyNw1qgCA5OSi4B4+HY4BtAoJSMGuD/L5hfTzoRVbzEm2WTvg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@shikijs/types": "1.17.7",
+				"@shikijs/types": "1.21.0",
 				"@shikijs/vscode-textmate": "^9.2.2"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.17.7.tgz",
-			"integrity": "sha512-+qA4UyhWLH2q4EFd+0z4K7GpERDU+c+CN2XYD3sC+zjvAr5iuwD1nToXZMt1YODshjkEGEDV86G7j66bKjqDdg==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.21.0.tgz",
+			"integrity": "sha512-tzndANDhi5DUndBtpojEq/42+dpUF2wS7wdCDQaFtIXm3Rd1QkrcVgSSRLOvEwexekihOXfbYJINW37g96tJRw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -3393,9 +3393,23 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.19.5",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-			"integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
+			"integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+			"version": "4.19.6",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+			"integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -3517,9 +3531,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.16.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
-			"integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+			"version": "20.16.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
+			"integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.2"
@@ -3568,9 +3582,9 @@
 			"peer": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.7",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.7.tgz",
-			"integrity": "sha512-KUnDCJF5+AiZd8owLIeVHqmW9yM4sqmDVf2JRJiBMFkGvkoZ4/WyV2lL4zVsoinmRS/W3FeEdZLEWFRofnT2FQ==",
+			"version": "18.3.10",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.10.tgz",
+			"integrity": "sha512-02sAAlBnP39JgXwkAq3PeU9DVaaGpZyF3MGcC0MKgQVkZor5IiiDAipVaxQHtDJAmO4GIy/rVBy/LzVj76Cyqg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -5207,15 +5221,19 @@
 			}
 		},
 		"node_modules/browserify-rsa": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-			"integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"bn.js": "^5.0.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "^5.2.1",
+				"randombytes": "^2.1.0",
+				"safe-buffer": "^5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/browserify-sign": {
@@ -5305,9 +5323,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+			"integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
 			"dev": true,
 			"funding": [
 				{
@@ -5326,8 +5344,8 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001646",
-				"electron-to-chromium": "^1.5.4",
+				"caniuse-lite": "^1.0.30001663",
+				"electron-to-chromium": "^1.5.28",
 				"node-releases": "^2.0.18",
 				"update-browserslist-db": "^1.1.0"
 			},
@@ -5548,9 +5566,9 @@
 			"license": "MIT"
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001662",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
-			"integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
+			"version": "1.0.30001664",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
+			"integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
 			"dev": true,
 			"funding": [
 				{
@@ -5646,9 +5664,9 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-			"integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6717,9 +6735,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-			"integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+			"integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)"
 		},
 		"node_modules/domutils": {
@@ -6747,9 +6765,9 @@
 			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.25",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz",
-			"integrity": "sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==",
+			"version": "1.5.30",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.30.tgz",
+			"integrity": "sha512-sXI35EBN4lYxzc/pIGorlymYNzDBOqkSlVRe6MkgBsW/hW1tpC/HDJ2fjG7XnjakzfLEuvdmux0Mjs6jHq4UOA==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -6780,9 +6798,9 @@
 			"peer": true
 		},
 		"node_modules/emoji-mart-vue-fast": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.2.tgz",
-			"integrity": "sha512-q7VaE6yRrlQd+jpHPToh1XnIatgACkQjBj0vQ7uNaWrbVsKlhZaOsqZVoegT5IZt5XkYoR2x4MHMNep/BJP9rw==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.3.tgz",
+			"integrity": "sha512-PBCzUb2iSLIF8LBHvp63vB3EWhrpGs0fg2JcHnHVKVNFOQeahkbU2NpkCtwFFa/Ed3ODKGUG9mcTzws4owxj4w==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@babel/runtime": "^7.18.6",
@@ -7254,9 +7272,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.0.tgz",
-			"integrity": "sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
+			"integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -8159,9 +8177,9 @@
 			"peer": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-			"integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+			"integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13602,9 +13620,9 @@
 			}
 		},
 		"node_modules/remark-rehype": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.0.tgz",
-			"integrity": "sha512-z3tJrAs2kIs1AqIIy6pzHmAHlF1hWQ+OdY4/hv+Wxe35EhyLKcajL33iUEn3ScxtFox9nUvRufR/Zre8Q08H/g==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
+			"integrity": "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -13897,9 +13915,9 @@
 			"peer": true
 		},
 		"node_modules/sass": {
-			"version": "1.79.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.1.tgz",
-			"integrity": "sha512-+mA7svoNKeL0DiJqZGeR/ZGUu8he4I8o3jyUcOFyo4eBJrwNgIMmAEwCMo/N2Y3wdjOBcRzoNxZIOtrtMX8EXg==",
+			"version": "1.79.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
+			"integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14344,16 +14362,16 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.17.7.tgz",
-			"integrity": "sha512-Zf6hNtWhFyF4XP5OOsXkBTEx9JFPiN0TQx4wSe+Vqeuczewgk2vT4IZhF4gka55uelm052BD5BaHavNqUNZd+A==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.21.0.tgz",
+			"integrity": "sha512-apCH5BoWTrmHDPGgg3RF8+HAAbEL/CdbYr8rMw7eIrdhCkZHdVGat5mMNlRtd1erNG01VPMIKHNQ0Pj2HMAiog==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@shikijs/core": "1.17.7",
-				"@shikijs/engine-javascript": "1.17.7",
-				"@shikijs/engine-oniguruma": "1.17.7",
-				"@shikijs/types": "1.17.7",
+				"@shikijs/core": "1.21.0",
+				"@shikijs/engine-javascript": "1.21.0",
+				"@shikijs/engine-oniguruma": "1.21.0",
+				"@shikijs/types": "1.21.0",
 				"@shikijs/vscode-textmate": "^9.2.2",
 				"@types/hast": "^3.0.4"
 			}
@@ -15313,9 +15331,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
-			"integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
+			"version": "5.34.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.34.1.tgz",
+			"integrity": "sha512-FsJZ7iZLd/BXkz+4xrRTGJ26o/6VTjQytUk8b8OxkwcD2I+79VPJlz7qss1+zE7h8GNIScFqXcDyJ/KqBYZFVA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true,
@@ -16133,9 +16151,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
 			"dev": true,
 			"funding": [
 				{
@@ -16154,8 +16172,8 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"escalade": "^3.1.2",
-				"picocolors": "^1.0.1"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -16640,9 +16658,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.94.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-			"integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+			"version": "5.95.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+			"integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,


### PR DESCRIPTION
Fixes `process` Node polyfill as described in changelog for [@nextcloud/webpack-vue-config](https://github.com/nextcloud-libraries/webpack-vue-config/releases/tag/v6.1.1).