### PR TITLE
chore: prepare 1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.4] - 2024-10-01
+
+### Changed
+
+- Bump @nextcloud/webpack-vue-config from 6.1.0 to 6.1.1. #22
+
 ## [1.0.3] - 2024-09-20
 
 ### Changed
@@ -36,7 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upload selected Nextcloud files to configured Zulip instance.
 
-[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.4
 [1.0.3]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.3
 [1.0.2]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.2
 [1.0.1]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ The context menu to send a file can be accessed by right clicking on the file/fo
 	<donation title="Donate via Liberapay">https://liberapay.com/edward-ly/donate</donation>
 	<donation title="Donate via PayPal" type="paypal">https://paypal.me/ledlight7</donation>
 	<dependencies>
-		<nextcloud min-version="28" max-version="30"/>
+		<nextcloud min-version="28" max-version="31"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Zulip\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ These values can be found in and copied from your Zulip account's `zuliprc` file
 If those settings are not configured, a link to the "Connected accounts" user settings page will be displayed when attempting to send a file to a Zulip user/topic.
 The context menu to send a file can be accessed by right clicking on the file/folder to be shared or selecting them and clicking on the "Actions" button.
 	]]></description>
-	<version>1.0.3</version>
+	<version>1.0.4</version>
 	<licence>agpl</licence>
 	<author>Edward Ly</author>
 	<namespace>Zulip</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "integration_zulip",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "integration_zulip",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "integration_zulip",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Zulip integration",
 	"scripts": {
 		"build": "NODE_ENV=production webpack --progress --config webpack.js",


### PR DESCRIPTION
## [1.0.4] - 2024-10-01

### Changed

- Bump @nextcloud/webpack-vue-config from 6.1.0 to 6.1.1. #22