### PR TITLE
chore: prepare 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2025-07-02
+
+### Changed
+
+- Switch to outlined icons. #53
+- Update npm packages. #39 #41 #42 #43 #46 #48 #49 #52
+- Update PHP packages. #44
+
 ## [1.1.0] - 2025-01-23
 
 ### Added
@@ -72,7 +80,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upload selected Nextcloud files to configured Zulip instance.
 
-[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.1
 [1.1.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.0
 [1.0.5]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.5
 [1.0.4]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.0.4

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ The context menu to send a file can be accessed by right clicking on the file/fo
 	<donation title="Donate via Liberapay">https://liberapay.com/edward-ly/donate</donation>
 	<donation title="Donate via PayPal" type="paypal">https://paypal.me/ledlight7</donation>
 	<dependencies>
-		<nextcloud min-version="28" max-version="31"/>
+		<nextcloud min-version="28" max-version="32"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Zulip\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ These values can be found in and copied from your Zulip account's `zuliprc` file
 If those settings are not configured, a link to the "Connected accounts" user settings page will be displayed when attempting to send a file to a Zulip user/topic.
 The context menu to send a file can be accessed by right clicking on the file/folder to be shared or selecting them and clicking on the "Actions" button.
 	]]></description>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<licence>agpl</licence>
 	<author>Edward Ly</author>
 	<namespace>Zulip</namespace>


### PR DESCRIPTION
### Changed

- Switch to outlined icons. #53
- Update npm packages.
  - #39
  - #41
  - #42
  - #43
  - #46
  - #48
  - #49
  - #52
- Update PHP packages. #44