### PR TITLE
chore: prepare 1.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.3] - 2025-07-22
+
+### Changed
+
+- Update npm packages. #59 #60
+
+### Fixed
+
+- Revert "revert outlining key icon". #61
+
 ## [1.1.2] - 2025-07-08
 
 ### Fixed
@@ -86,7 +96,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upload selected Nextcloud files to configured Zulip instance.
 
-[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.3
 [1.1.2]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.2
 [1.1.1]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.1
 [1.1.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ These values can be found in and copied from your Zulip account's `zuliprc` file
 If those settings are not configured, a link to the "Connected accounts" user settings page will be displayed when attempting to send a file to a Zulip user/topic.
 The context menu to send a file can be accessed by right clicking on the file/folder to be shared or selecting them and clicking on the "Actions" button.
 	]]></description>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 	<licence>agpl</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>Zulip</namespace>


### PR DESCRIPTION
### Changed

- Update npm packages. #59 #60

### Fixed

- Revert "revert outlining key icon". #61
