### PR TITLE
chore: prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-04-13
+
+### Changed
+
+- Bump max supported Nextcloud version to 34. #92
+- Migrate to Vue 3. #85
+- Update npm packages. #84 #86 #88 #89 #90 #91 #93 #94 #95 #96 #97 #98 #99 #101 #105 #106 #108
+- Update composer packages. #87
+
+### Fixed
+
+- Breaking change in file actions. #92
+
 ## [2.1.0] - 2025-12-19
 
 ### Changed
@@ -133,7 +146,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upload selected Nextcloud files to configured Zulip instance.
 
-[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.2.0
 [2.1.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.1.0
 [2.0.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.0.0
 [1.1.5]: https://github.com/nextcloud/integration_zulip/releases/tag/v1.1.5

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ These values can be found in and copied from your Zulip account's `zuliprc` file
 If those settings are not configured, a link to the "Connected accounts" user settings page will be displayed when attempting to send a file to a Zulip user/topic.
 The context menu to send a file can be accessed by right clicking on the file/folder to be shared or selecting them and clicking on the "Actions" button.
 	]]></description>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>Zulip</namespace>


### PR DESCRIPTION
### Changed

- Bump max supported Nextcloud version to 34. #92
- Migrate to Vue 3. #85
- Update npm packages. #84 #86 #88 #89 #90 #91 #93 #94 #95 #96 #97 #98 #99 #101 #105 #106 #108
- Update composer packages. #87

### Fixed

- Breaking change in file actions. #92