### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6115,14 +6115,13 @@
 			}
 		},
 		"node_modules/browserify-sign": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-			"integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+			"integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
 			"dev": true,
-			"license": "ISC",
 			"peer": true,
 			"dependencies": {
-				"bn.js": "^5.2.2",
+				"bn.js": "^5.2.3",
 				"browserify-rsa": "^4.1.1",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 12 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/eslint-config](#user-content-\\@nextcloud\\/eslint-config)
## Fixed vulnerabilities

### `@nextcloud/eslint-config` <a href="#user-content-\@nextcloud\/eslint-config" id="\@nextcloud\/eslint-config">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/eslint-plugin](#user-content-\@nextcloud\/eslint-plugin)
* Affected versions: 8.4.0 - 8.4.2
* Package usage:
  * `node_modules/@nextcloud/eslint-config`