### PR TITLE
chore: prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-22
+
+### Added
+
+- Dashboard widget displaying latest/unread Zulip messages. #126
+
+### Changed
+
+- Bump max supported Nextcloud version to 35. #135
+- Update npm packages. #110 #111 #112 #113 #117 #118 #119 #122 #124 #125 #127 #129 #134
+
 ## [2.2.0] - 2026-04-13
 
 ### Changed
@@ -146,7 +157,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upload selected Nextcloud files to configured Zulip instance.
 
-[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_zulip/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.3.0
 [2.2.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.2.0
 [2.1.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.1.0
 [2.0.0]: https://github.com/nextcloud/integration_zulip/releases/tag/v2.0.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The context menu to send a file can be accessed by right clicking on the file/fo
 	<donation title="Donate via Liberapay">https://liberapay.com/edward-ly/donate</donation>
 	<donation title="Donate via PayPal" type="paypal">https://paypal.me/ledlight7</donation>
 	<dependencies>
-		<nextcloud min-version="33" max-version="34"/>
+		<nextcloud min-version="33" max-version="35"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Zulip\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@ These values can be found in and copied from your Zulip account's `zuliprc` file
 If those settings are not configured, a link to the "Connected accounts" user settings page will be displayed when attempting to send a file to a Zulip user/topic.
 The context menu to send a file can be accessed by right clicking on the file/folder to be shared or selecting them and clicking on the "Actions" button.
 	]]></description>
-	<version>2.2.0</version>
+	<version>2.3.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>Zulip</namespace>


### PR DESCRIPTION
Quick win that I forgot to do last week.

### Added

- Dashboard widget displaying latest/unread Zulip messages. #126

### Changed

- Bump max supported Nextcloud version to 35. #135
- Update npm packages. #110 #111 #112 #113 #117 #118 #119 #122 #124 #125 #127 #129 #134
