### PR TITLE
feat(admin): add admin settings for file sharing options

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -22,6 +22,7 @@ use OCA\Zulip\AppInfo\Application;
 use OCA\Zulip\Service\SecretService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
@@ -75,6 +76,22 @@ class ConfigController extends Controller {
 			$this->config->setUserValue($this->userId, Application::APP_ID, $key, $value);
 		}
 
+		return new DataResponse([]);
+	}
+
+	/**
+	 * @return DataResponse
+	 */
+	#[AuthorizedAdminSetting(settings: \OCA\Zulip\Settings\Admin::class)]
+	#[FrontpageRoute(verb: 'PUT', url: '/admin-config')]
+	public function setAdminConfig(array $values): DataResponse {
+		$allowedKeys = ['send_type_enabled_file', 'send_type_enabled_public_link', 'send_type_enabled_internal_link', 'send_type_default'];
+		foreach ($values as $key => $value) {
+			if (!in_array($key, $allowedKeys, true)) {
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
+			$this->config->setAppValue(Application::APP_ID, $key, $value);
+		}
 		return new DataResponse([]);
 	}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -2,16 +2,15 @@
 
 declare(strict_types=1);
 
-namespace OCA\Zulip\AppInfo;
+namespace OCA\Zulip\Settings;
 
-use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCA\Zulip\AppInfo\Application;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
+use OCP\Settings\ISettings;
 
-/** @template-implements IEventListener<BeforeTemplateRenderedEvent|Event> */
-class BeforeTemplateRenderedListener implements IEventListener {
+class Admin implements ISettings {
 
 	public function __construct(
 		private IConfig $config,
@@ -19,15 +18,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	) {
 	}
 
-	public function handle(Event $event): void {
-		if (!($event instanceof BeforeTemplateRenderedEvent)) {
-			return;
-		}
-		if (!$event->isLoggedIn()) {
-			return;
-		}
-		\OCP\Util::addStyle(Application::APP_ID, 'zulip-search');
-
+	public function getForm(): TemplateResponse {
 		$adminConfig = [
 			'send_type_enabled_file' => $this->config->getAppValue(Application::APP_ID, 'send_type_enabled_file', '1') === '1',
 			'send_type_enabled_public_link' => $this->config->getAppValue(Application::APP_ID, 'send_type_enabled_public_link', '1') === '1',
@@ -35,5 +26,14 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			'send_type_default' => $this->config->getAppValue(Application::APP_ID, 'send_type_default', ''),
 		];
 		$this->initialStateService->provideInitialState('admin-config', $adminConfig);
+		return new TemplateResponse(Application::APP_ID, 'adminSettings');
+	}
+
+	public function getSection(): string {
+		return 'connected-accounts';
+	}
+
+	public function getPriority(): int {
+		return 10;
 	}
 }

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Zulip\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+class AdminSection implements IIconSection {
+
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+		private IL10N $l,
+	) {
+	}
+
+	public function getID(): string {
+		return 'connected-accounts';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Connected accounts');
+	}
+
+	public function getPriority(): int {
+		return 80;
+	}
+
+	public function getIcon(): string {
+		return $this->urlGenerator->imagePath('core', 'categories/integration.svg');
+	}
+}

--- a/src/adminSettings.js
+++ b/src/adminSettings.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import AdminSettings from './components/AdminSettings.vue'
+
+const app = createApp(AdminSettings)
+app.mixin({ methods: { t, n } })
+app.mount('#zulip_prefs')

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -1,0 +1,197 @@
+<template>
+	<div id="zulip_prefs" class="section">
+		<h2>
+			<ZulipIcon class="icon" />
+			{{ t('integration_zulip', 'Zulip integration') }}
+		</h2>
+		<div id="zulip-content">
+			<h3>{{ t('integration_zulip', 'File sharing options') }}</h3>
+			<p class="settings-hint">
+				{{ t('integration_zulip', 'Configure which sharing options are available to users when sending files to Zulip.') }}
+			</p>
+			<NcFormBox>
+				<NcFormBoxSwitch
+					v-model="state.send_type_enabled_file"
+					:disabled="isOnlyEnabled('file')"
+					@update:model-value="onCheckboxChanged($event, 'send_type_enabled_file')">
+					{{ t('integration_zulip', 'Allow uploading files') }}
+				</NcFormBoxSwitch>
+				<NcFormBoxSwitch
+					v-model="state.send_type_enabled_public_link"
+					:disabled="isOnlyEnabled('public_link')"
+					@update:model-value="onCheckboxChanged($event, 'send_type_enabled_public_link')">
+					{{ t('integration_zulip', 'Allow sending public links') }}
+				</NcFormBoxSwitch>
+				<NcFormBoxSwitch
+					v-model="state.send_type_enabled_internal_link"
+					:disabled="isOnlyEnabled('internal_link')"
+					@update:model-value="onCheckboxChanged($event, 'send_type_enabled_internal_link')">
+					{{ t('integration_zulip', 'Allow sending internal links') }}
+				</NcFormBoxSwitch>
+			</NcFormBox>
+			<div v-if="enabledSendTypes.length > 1" class="default-type-section">
+				<h3>{{ t('integration_zulip', 'Default sharing option') }}</h3>
+				<p class="settings-hint">
+					{{ t('integration_zulip', 'Select which option is pre-selected when users open the sharing dialog.') }}
+				</p>
+				<div class="default-type-radios">
+					<NcCheckboxRadioSwitch
+						v-model="defaultSendType"
+						value="first_available"
+						name="default_send_type_radio"
+						type="radio">
+						{{ t('integration_zulip', 'First available option') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						v-if="state.send_type_enabled_file"
+						v-model="defaultSendType"
+						value="file"
+						name="default_send_type_radio"
+						type="radio">
+						{{ t('integration_zulip', 'Upload files') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						v-if="state.send_type_enabled_public_link"
+						v-model="defaultSendType"
+						value="public_link"
+						name="default_send_type_radio"
+						type="radio">
+						{{ t('integration_zulip', 'Public links') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch
+						v-if="state.send_type_enabled_internal_link"
+						v-model="defaultSendType"
+						value="internal_link"
+						name="default_send_type_radio"
+						type="radio">
+						{{ t('integration_zulip', 'Internal links') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import ZulipIcon from './icons/ZulipIcon.vue'
+
+import NcFormBox from '@nextcloud/vue/components/NcFormBox'
+import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+
+import axios from '@nextcloud/axios'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'AdminSettings',
+
+	components: {
+		ZulipIcon,
+		NcFormBox,
+		NcFormBoxSwitch,
+		NcCheckboxRadioSwitch,
+	},
+
+	data() {
+		return {
+			state: loadState('integration_zulip', 'admin-config'),
+		}
+	},
+
+	computed: {
+		enabledSendTypes() {
+			return [
+				this.state.send_type_enabled_file && 'file',
+				this.state.send_type_enabled_public_link && 'public_link',
+				this.state.send_type_enabled_internal_link && 'internal_link',
+			].filter(Boolean)
+		},
+		defaultSendType: {
+			get() {
+				return this.state.send_type_default === '' ? 'first_available' : this.state.send_type_default
+			},
+			set(value) {
+				this.onDefaultTypeChanged(value === 'first_available' ? '' : value)
+			},
+		},
+	},
+
+	watch: {
+		enabledSendTypes(newTypes) {
+			if (this.state.send_type_default !== '' && !newTypes.includes(this.state.send_type_default)) {
+				this.onDefaultTypeChanged('')
+			}
+		},
+	},
+
+	methods: {
+		isOnlyEnabled(key) {
+			return this.enabledSendTypes.length === 1 && this.enabledSendTypes[0] === key
+		},
+		onCheckboxChanged(newValue, key) {
+			this.saveAdminConfig({ [key]: newValue ? '1' : '0' })
+		},
+		onDefaultTypeChanged(value) {
+			this.state.send_type_default = value
+			this.saveAdminConfig({ send_type_default: value })
+		},
+		saveAdminConfig(values) {
+			const req = { values }
+			const url = generateUrl('/apps/integration_zulip/admin-config')
+			axios.put(url, req)
+				.then(() => {
+					showSuccess(t('integration_zulip', 'Zulip admin options saved'))
+				})
+				.catch((error) => {
+					showError(
+						t('integration_zulip', 'Failed to save Zulip admin options')
+						+ ': ' + (error.response?.request?.responseText ?? ''),
+					)
+					console.error(error)
+				})
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+#zulip_prefs {
+	#zulip-content {
+		margin-left: 40px;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		max-width: 800px;
+	}
+
+	h2 {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		justify-content: start;
+	}
+
+	h3 {
+		margin-top: 16px;
+		margin-bottom: 4px;
+	}
+
+	.settings-hint {
+		color: var(--color-text-maxcontrast);
+		margin-bottom: 8px;
+	}
+
+	.default-type-section {
+		margin-top: 16px;
+	}
+
+	.default-type-radios {
+		margin-left: 10px;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+}
+</style>

--- a/src/components/SendFilesModal.vue
+++ b/src/components/SendFilesModal.vue
@@ -152,7 +152,7 @@
 						</span>
 					</span>
 					<div>
-						<NcCheckboxRadioSwitch v-for="(type, key) in SEND_TYPE"
+						<NcCheckboxRadioSwitch v-for="(type, key) in availableSendTypes"
 							:key="key"
 							v-model="sendType"
 							:value="type.id"
@@ -309,12 +309,24 @@ export default {
 		UploadBoxOutlineIcon,
 	},
 
+	props: {
+		adminConfig: {
+			type: Object,
+			default: () => ({
+				send_type_enabled_file: true,
+				send_type_enabled_public_link: true,
+				send_type_enabled_internal_link: true,
+				send_type_default: '',
+			}),
+		},
+	},
+
 	data() {
 		return {
 			SEND_TYPE,
 			show: false,
 			loading: false,
-			sendType: SEND_TYPE.file.id,
+			sendType: this.resolveDefaultSendType(),
 			comment: '',
 			query: '',
 			files: [],
@@ -339,6 +351,11 @@ export default {
 	},
 
 	computed: {
+		availableSendTypes() {
+			return Object.fromEntries(
+				Object.entries(SEND_TYPE).filter(([key]) => this.adminConfig[`send_type_enabled_${key}`] !== false),
+			)
+		},
 		warnAboutSendingDirectories() {
 			return this.sendType === SEND_TYPE.file.id && this.files.findIndex((f) => f.type === 'dir') !== -1
 		},
@@ -359,7 +376,7 @@ export default {
 	},
 
 	watch: {
-		selectedChannel(newChannel, oldChannel) {
+		selectedChannel(newChannel) {
 			if (newChannel?.type === 'channel') {
 				this.updateTopics()
 			}
@@ -371,6 +388,19 @@ export default {
 	},
 
 	methods: {
+		resolveDefaultSendType() {
+			const def = this.adminConfig?.send_type_default
+			if (def && this.adminConfig?.[`send_type_enabled_${def}`] !== false) {
+				return def
+			}
+			// Fall back to first enabled type
+			for (const key of Object.keys(SEND_TYPE)) {
+				if (this.adminConfig?.[`send_type_enabled_${key}`] !== false) {
+					return key
+				}
+			}
+			return SEND_TYPE.file.id
+		},
 		reset() {
 			this.selectedChannel = null
 			this.selectedTopic = null
@@ -379,7 +409,7 @@ export default {
 			this.channels = undefined
 			this.topics = undefined
 			this.comment = ''
-			this.sendType = SEND_TYPE.file.id
+			this.sendType = this.resolveDefaultSendType()
 			this.selectedPermission = 'view'
 			this.expirationEnabled = false
 			this.expirationDate = null

--- a/src/filesplugin.js
+++ b/src/filesplugin.js
@@ -18,6 +18,7 @@ import moment from '@nextcloud/moment'
 import { generateUrl, linkTo } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import { loadState } from '@nextcloud/initial-state'
 import { SEND_TYPE } from './utils.js'
 import {
 	registerFileAction, Permission, FileType,
@@ -186,7 +187,19 @@ const modalElement = document.createElement('div')
 modalElement.id = modalId
 document.body.append(modalElement)
 
-const modalApp = createApp(SendFilesModal)
+let adminConfig = {
+	send_type_enabled_file: true,
+	send_type_enabled_public_link: true,
+	send_type_enabled_internal_link: true,
+	send_type_default: '',
+}
+try {
+	adminConfig = loadState('integration_zulip', 'admin-config', adminConfig)
+} catch (e) {
+	// admin-config not available, use defaults
+}
+
+const modalApp = createApp(SendFilesModal, { adminConfig })
 modalApp.mixin({ methods: { t, n } })
 OCA.Zulip.ZulipSendModalVue = modalApp.mount(modalElement)
 

--- a/webpack.js
+++ b/webpack.js
@@ -14,6 +14,7 @@ webpackConfig.stats = {
 
 const appId = 'integration_zulip'
 webpackConfig.entry = {
+	adminSettings: { import: path.join(__dirname, 'src', 'adminSettings.js'), filename: appId + '-adminSettings.js' },
 	personalSettings: { import: path.join(__dirname, 'src', 'personalSettings.js'), filename: appId + '-personalSettings.js' },
 	filesplugin: { import: path.join(__dirname, 'src', 'filesplugin.js'), filename: appId + '-filesplugin.js' },
 	popupSuccess: { import: path.join(__dirname, 'src', 'popupSuccess.js'), filename: appId + '-popupSuccess.js' },


### PR DESCRIPTION
This is my answer to #128 

Admins can now configure which sharing options (upload, public link, internal link) are available to users, and which one is pre-selected by default in the send files dialog.

If nothing is configured, behavior is unchanged: all three options are available and the upload option is pre-selected.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>



## 🤖 AI (if applicable)

- [x ] The content of this PR was partly or fully generated using AI
